### PR TITLE
refactor: Refresh 저장소를 MySQL->Redis로 변경

### DIFF
--- a/src/main/java/com/tae/Etickette/global/auth/CustomLogoutFilter.java
+++ b/src/main/java/com/tae/Etickette/global/auth/CustomLogoutFilter.java
@@ -87,7 +87,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
         //로그아웃을 진행한다.
 
         // 1. Refresh 토큰을 DB에서 제거
-        refreshTokenService.deleteByRefresh(refresh);
+        refreshTokenService.deleteByMember(jwtUtil.getEmail(refresh));
 
         //Refresh 토큰 Cookie 값 0
         Cookie cookie = CookieUtil.createCookie("refresh", null, 0);

--- a/src/main/java/com/tae/Etickette/global/jwt/LoginFilter.java
+++ b/src/main/java/com/tae/Etickette/global/jwt/LoginFilter.java
@@ -80,7 +80,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String access = jwtUtil.createJwt("access", email, role, 1000L * 60 * 10);
         String refresh = jwtUtil.createJwt("refresh", email, role, 1000L * 60 * 60 * 24);
 
-        refreshTokenService.saveRefresh(email, refresh, 60 * 60 * 24);
+        refreshTokenService.saveRefresh(email, refresh, 1000L * 60 * 60 * 24);
         //HTTP 인증 방식은 RFC 7235 정의에 따라 아래 인증 헤더 형태를 가져야 한다.
         response.addHeader("Authorization","Bearer " + access);
         response.addCookie(CookieUtil.createCookie("refresh",refresh,60 * 60 * 24));

--- a/src/main/java/com/tae/Etickette/global/oauth/CustomSuccessHandler.java
+++ b/src/main/java/com/tae/Etickette/global/oauth/CustomSuccessHandler.java
@@ -44,7 +44,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String access = jwtUtil.createJwt("access", email, role, 1000L * 60 * 10);
         String refresh = jwtUtil.createJwt("refresh", email, role, 1000L * 60 * 60 * 24);
 
-        refreshTokenService.saveRefresh(email, refresh, 60 * 60 * 24);
+        refreshTokenService.saveRefresh(email, refresh, 1000L * 60 * 60 * 24);
 
         response.addCookie(CookieUtil.createCookie("Authorization", access, 60 * 10));
         response.addCookie(CookieUtil.createCookie("refresh", refresh, 60 * 60 * 24));

--- a/src/main/java/com/tae/Etickette/global/refresh/application/RefreshTokenService.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/application/RefreshTokenService.java
@@ -16,9 +16,9 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public void saveRefresh(String email, String refresh, Integer expiredMs) {
-        RefreshToken refreshToken = RefreshToken.create(email, refresh,
-                new Date(System.currentTimeMillis() + expiredMs * 1000L).toString());
+    public void saveRefresh(String email, String refresh, Long expiredMs) {
+        RefreshToken refreshToken = new RefreshToken(email, refresh,
+                expiredMs);
 
         refreshTokenRepository.save(refreshToken);
     }

--- a/src/main/java/com/tae/Etickette/global/refresh/application/RefreshTokenService.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/application/RefreshTokenService.java
@@ -30,7 +30,7 @@ public class RefreshTokenService {
 
     @Transactional
     public void deleteByMember(String memberEmail) {
-        refreshTokenRepository.deleteByEmail(memberEmail);
+        refreshTokenRepository.deleteById(memberEmail);
     }
 
     public Boolean existsByRefresh(String refresh){

--- a/src/main/java/com/tae/Etickette/global/refresh/application/ReissueService.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/application/ReissueService.java
@@ -66,7 +66,7 @@ public class ReissueService {
         String newRefresh = jwtUtil.createJwt("refresh", email, role, 1000L * 60 * 60 * 24);
 
         //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
-        refreshTokenService.deleteByRefresh(refresh);
+        refreshTokenService.deleteByMember(email);
         refreshTokenService.saveRefresh(email, newRefresh, 1000L * 60 * 60 * 24);
 
         //response

--- a/src/main/java/com/tae/Etickette/global/refresh/application/ReissueService.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/application/ReissueService.java
@@ -67,7 +67,7 @@ public class ReissueService {
 
         //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
         refreshTokenService.deleteByRefresh(refresh);
-        refreshTokenService.saveRefresh(email, newRefresh, 60 * 60 * 24);
+        refreshTokenService.saveRefresh(email, newRefresh, 1000L * 60 * 60 * 24);
 
         //response
         response.setHeader("Authorization", "Bearer " + newAccess);

--- a/src/main/java/com/tae/Etickette/global/refresh/domain/RefreshToken.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/domain/RefreshToken.java
@@ -1,31 +1,29 @@
 package com.tae.Etickette.global.refresh.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import java.util.concurrent.TimeUnit;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
-@Entity
+@RedisHash(value = "refreshToken")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
     private String email;
+    @Indexed
     private String refresh;
-    private String expiration;
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private long expiration;
 
-    public RefreshToken(String email, String refresh, String expiration) {
+    public RefreshToken(String email, String refresh, long expiration) {
         this.email = email;
         this.refresh = refresh;
         this.expiration = expiration;
     }
 
-    public static RefreshToken create(String email, String refresh, String expiration) {
-        return new RefreshToken(email, refresh, expiration);
-    }
 }

--- a/src/main/java/com/tae/Etickette/global/refresh/infra/RefreshTokenRepository.java
+++ b/src/main/java/com/tae/Etickette/global/refresh/infra/RefreshTokenRepository.java
@@ -2,8 +2,9 @@ package com.tae.Etickette.global.refresh.infra;
 
 import com.tae.Etickette.global.refresh.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 
     Boolean existsByRefresh(String refresh);
     void deleteByRefresh(String refresh);

--- a/src/test/java/com/tae/Etickette/integration/service/MemberServiceTest.java
+++ b/src/test/java/com/tae/Etickette/integration/service/MemberServiceTest.java
@@ -130,7 +130,7 @@ public class MemberServiceTest {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void 회원삭제_성공_이벤트() {
         //given
-        refreshTokenRepository.save(new RefreshToken("event@spring", "refresh.token.event", "expiration"));
+        refreshTokenRepository.save(new RefreshToken("event@spring", "refresh.token.event", 1L));
 
         RegisterMemberRequest member = RegisterMemberRequest.builder()
                 .name("USER")
@@ -142,7 +142,6 @@ public class MemberServiceTest {
 
         //when
         memberService.deleteMember(request,"event@spring");
-        refreshTokenRepository.flush();
 
         //then
         Assertions.assertThat(refreshTokenRepository.existsByRefresh("refresh.token.event")).isFalse();


### PR DESCRIPTION
- Refresh 저장소를 Redis로 변경
- 토큰 삭제 로직 시, 회원 email로 검색할 수 있도록 수정
- 토큰 저장소 인터페이스 수정 JpaRepo->CrudRepo
- Refresh 엔티티에서 ttl 설정을 위하여, ms 단위의 값을 입력 받을 수 있도록 수정